### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!Warning]
+> Support for MATLAB has been deprecated.
+> This repository still exists as a reference, but may also be deleted.
+
 # MATLAB samples
 
 This repository contains matlab code samples for Zivid SDK v2.16.0. For


### PR DESCRIPTION
Zivid no longer mantains matlab samples actively.